### PR TITLE
Correct scope for auth in post deployment scripts, rename and fixup openrcs

### DIFF
--- a/bin/neutron-ext-net-ksv3
+++ b/bin/neutron-ext-net-ksv3
@@ -62,7 +62,8 @@ if __name__ == '__main__':
         user_domain_name=os.environ['OS_USER_DOMAIN_NAME'],
         username=os.environ['OS_USERNAME'],
         password=os.environ['OS_PASSWORD'],
-        domain_name=os.environ['OS_DOMAIN_NAME'],
+        project_domain_name=os.environ['OS_PROJECT_DOMAIN_NAME'],
+        project_name=os.environ['OS_PROJECT_NAME'],
         auth_url=os.environ['OS_AUTH_URL'])
     sess = session.Session(auth=auth)
 

--- a/bin/neutron-tenant-net-ksv3
+++ b/bin/neutron-tenant-net-ksv3
@@ -62,7 +62,8 @@ if __name__ == '__main__':
         user_domain_name=os.environ['OS_USER_DOMAIN_NAME'],
         username=os.environ['OS_USERNAME'],
         password=os.environ['OS_PASSWORD'],
-        domain_name=os.environ['OS_DOMAIN_NAME'],
+        project_domain_name=os.environ['OS_PROJECT_DOMAIN_NAME'],
+        project_name=os.environ['OS_PROJECT_NAME'],
         auth_url=os.environ['OS_AUTH_URL'])
     sess = session.Session(auth=auth)
 

--- a/novarc
+++ b/novarc
@@ -1,0 +1,1 @@
+rcs/openrcv2

--- a/novarcv3_domain
+++ b/novarcv3_domain
@@ -1,0 +1,1 @@
+rcs/openrcv3_domain

--- a/novarcv3_project
+++ b/novarcv3_project
@@ -1,0 +1,1 @@
+rcs/openrcv3_project

--- a/profiles/arm64v3
+++ b/profiles/arm64v3
@@ -20,23 +20,34 @@ set -ex
 net_type=${1:-"gre"}
 
 # Configure neutron networking on overcloud
-source novarcv3_domain
+source novarcv3_project
 ./bin/neutron-ext-net-ksv3 --project admin --network-type flat -g $GATEWAY -c $CIDR_EXT -f $FIP_RANGE ext_net
 ./bin/neutron-tenant-net-ksv3 --project admin --network-type $net_type -r provider-router -N $NAMESERVER private $CIDR_PRIV
 ext_net=$(openstack network list | awk '/ext_net/ {print $2}')
 
 # Create demo/testing users, tenants and flavor
-openstack project show demo || openstack project create demo
-openstack user show demo || openstack user create --project demo --password pass --enable --email demo@dev.null demo
+openstack project show --domain admin_domain demo || \
+	openstack project create --domain admin_domain demo
+openstack user show --domain admin_domain demo || \
+	openstack user create --project-domain admin_domain --project demo \
+	--password pass --enable --email demo@dev.null \
+	--domain admin_domain demo
 openstack role show Member || openstack role create Member
-openstack role add --user demo --project demo Member
-openstack project show alt_demo || openstack project create alt_demo
-openstack user show alt_demo || openstack user create --project alt_demo --password secret --enable --email alt_demo@dev.null alt_demo
-openstack role add --user alt_demo --project alt_demo Member
-access=$(openstack ec2 credentials create --user demo --project demo  | awk '/access/ {print $4}')
+openstack role add --user-domain admin_domain --user demo \
+	--project-domain admin_domain --project demo Member
+openstack project show --domain admin_domain alt_demo || \
+	openstack project create --domain admin_domain alt_demo
+openstack user show --domain admin_domain alt_demo || \
+	openstack user create --project-domain admin_domain --project alt_demo \
+	--password secret --enable --email alt_demo@dev.null \
+	--domain admin_domain alt_demo
+openstack role add --user-domain admin_domain --user alt_demo \
+	--project-domain admin_domain --project alt_demo Member
+access=$(openstack ec2 credentials create --user-domain admin_domain \
+	--user demo --project-domain admin_domain --project demo \
+       | awk '/access/ {print $4}')
 secret=$(openstack ec2 credentials show $access  | awk '/secret/ {print $4}')
 
-source novarcv3_project
 # Download images if not already present
 tools/images_arm64.sh
 

--- a/profiles/keystonev3
+++ b/profiles/keystonev3
@@ -46,23 +46,34 @@ if [[ "${BARE_METAL^^}" != "TRUE" ]]; then
 fi
 
 # Configure neutron networking on overcloud
-source novarcv3_domain
+source novarcv3_project
 ./bin/neutron-ext-net-ksv3 --project admin --network-type flat -g $GATEWAY -c $CIDR_EXT -f $FIP_RANGE ext_net
 ./bin/neutron-tenant-net-ksv3 --project admin --network-type $net_type -r provider-router -N $NAMESERVER private $CIDR_PRIV
 ext_net=$(openstack network list | awk '/ext_net/ {print $2}')
 
 # Create demo/testing users, tenants and flavor
-openstack project show demo || openstack project create demo
-openstack user show demo || openstack user create --project demo --password pass --enable --email demo@dev.null demo
+openstack project show --domain admin_domain demo || \
+	openstack project create --domain admin_domain demo
+openstack user show --domain admin_domain demo || \
+	openstack user create --project-domain admin_domain --project demo \
+	--password pass --enable --email demo@dev.null \
+	--domain admin_domain demo
 openstack role show Member || openstack role create Member
-openstack role add --user demo --project demo Member
-openstack project show alt_demo || openstack project create alt_demo
-openstack user show alt_demo || openstack user create --project alt_demo --password secret --enable --email alt_demo@dev.null alt_demo
-openstack role add --user alt_demo --project alt_demo Member
-access=$(openstack ec2 credentials create --user demo --project demo  | awk '/access/ {print $4}')
+openstack role add --user-domain admin_domain --user demo \
+	--project-domain admin_domain --project demo Member
+openstack project show --domain admin_domain alt_demo || \
+	openstack project create --domain admin_domain alt_demo
+openstack user show --domain admin_domain alt_demo || \
+	openstack user create --project-domain admin_domain --project alt_demo \
+	--password secret --enable --email alt_demo@dev.null \
+	--domain admin_domain alt_demo
+openstack role add --user-domain admin_domain --user alt_demo \
+	--project-domain admin_domain --project alt_demo Member
+access=$(openstack ec2 credentials create --user-domain admin_domain \
+	--user demo --project-domain admin_domain --project demo \
+       | awk '/access/ {print $4}')
 secret=$(openstack ec2 credentials show $access  | awk '/secret/ {print $4}')
 
-source novarcv3_project
 # Download images if not already present
 mkdir -vp ~/images
 upload_image cloudimages xenial xenial-server-cloudimg-amd64-disk1.img

--- a/rcs/openrc
+++ b/rcs/openrc
@@ -1,0 +1,15 @@
+_keystone_unit=$(juju status keystone --format yaml | \
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+_keystone_major_version=$(juju status ${_keystone_unit} --format yaml| \
+    awk '/^    version:/ {print $2}' | cut -f1 -d\.)
+_keystone_preferred_api_version=$(juju config keystone preferred-api-version)
+_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
+
+if [ $_keystone_major_version -ge 13 -o \
+     "$_keystone_preferred_api_version" = '3' ]; then
+    echo Using Keystone v3 API
+    . $(dirname ${BASH_SOURCE[@]})/openrcv3_project
+else
+    echo Using Keystone v2.0 API
+    . $(dirname ${BASH_SOURCE[@]})/openrcv2
+fi

--- a/rcs/openrcv2
+++ b/rcs/openrcv2
@@ -2,10 +2,15 @@ _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
     unset $param
 done
+
+_keystone_unit=$(juju status keystone --format yaml | \
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
+
 unset _OS_PARAMS
 export OS_USERNAME=admin
 export OS_PASSWORD=openstack
 export OS_TENANT_NAME=admin
 export OS_REGION_NAME=RegionOne
-export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju-deployer -f keystone`:5000/v2.0
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v2.0
 export OS_AUTH_TYPE=password

--- a/rcs/openrcv3_domain
+++ b/rcs/openrcv3_domain
@@ -3,7 +3,12 @@ for param in $_OS_PARAMS; do
     unset $param
 done
 unset _OS_PARAMS
-export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju-deployer -f keystone`:5000/v3
+
+_keystone_unit=$(juju status keystone --format yaml | \
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
+
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
 export OS_USERNAME=admin
 export OS_PASSWORD=openstack
 export OS_REGION_NAME=RegionOne

--- a/rcs/openrcv3_project
+++ b/rcs/openrcv3_project
@@ -3,7 +3,12 @@ for param in $_OS_PARAMS; do
     unset $param
 done
 unset _OS_PARAMS
-export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju-deployer -f keystone`:5000/v3
+
+_keystone_unit=$(juju status keystone --format yaml | \
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
+
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
 export OS_USERNAME=admin
 export OS_PASSWORD=openstack
 export OS_USER_DOMAIN_NAME=admin_domain


### PR DESCRIPTION
Post deployment configuration script currently relies on
the OS_DOMAIN_NAME environment variable and requests a
domain scoped token when authenticating to Keystone.

Holding a domain scoped token is generally not useful for
actually using resources on a cloud and in most if not all
circumstances you should use a project scoped token.

When we initially implemented API v3 support in the Keystone
charm [0] we chose to use a advanced policy that enables
domain segregation and administration delegation [1]. It is
important to understand that this differs from the default
policy distributed with the upstream Keystone project.

In the initial implementation it was necessary to switch
between using a `domain` scoped and `project` scoped token to
successfully manage a cloud, but since the introduction of
`is_admin` functionality in Keystone [2][3][4] and our
subsequent adoption of it in Keystone charm [5], this is no
longer necessary.

0: https://github.com/openstack/charm-keystone/commit/c283a1c922a903133ef31627203a56b951129324
1: https://github.com/openstack/keystone/commit/c7a5c6cf27a80ca50db9f1a1a74e8795eeefd9d1
2: https://github.com/openstack/keystone/commit/e7023697a884759716d0a01605825a3af90d4db6
3: https://github.com/openstack/keystone/commit/e923a14afdd8994129a17ece57dd220c307888dc
4: https://github.com/openstack/keystone/commit/9804081a80ef815a86407a64f967986a7bf9ba25
5: https://github.com/openstack/charm-keystone/commit/10e3d84effcadd9c527d5d18f8bdd0d25003b85a