### PR TITLE
updated nameservers from lescina to ruxton in some legacy profiles

### DIFF
--- a/profiles/amd64-v3
+++ b/profiles/amd64-v3
@@ -12,7 +12,7 @@ set -ex
 [[ -z "$GATEWAY" ]] && export GATEWAY="10.245.168.1"
 [[ -z "$CIDR_EXT" ]] && export CIDR_EXT="10.245.168.0/21"
 [[ -z "$FIP_RANGE" ]] && export FIP_RANGE="10.245.171.0:10.245.171.255"
-[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.2"
+[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.6"
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/22"
 [[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"
 

--- a/profiles/dellstack
+++ b/profiles/dellstack
@@ -6,7 +6,7 @@ set -ex
 [[ -z "$GATEWAY" ]] && export GATEWAY="10.245.168.1"
 [[ -z "$CIDR_EXT" ]] && export CIDR_EXT="10.245.168.0/21"
 [[ -z "$FIP_RANGE" ]] && export FIP_RANGE="10.245.171.0:10.245.171.255"
-[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.2"
+[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.6"
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/22"
 [[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"
 

--- a/profiles/powerkvm
+++ b/profiles/powerkvm
@@ -13,7 +13,7 @@
 [[ -z "$GATEWAY" ]] && export GATEWAY="10.245.168.1"
 [[ -z "$CIDR_EXT" ]] && export CIDR_EXT="10.245.168.0/21"
 [[ -z "$FIP_RANGE" ]] && export FIP_RANGE="10.245.173.0:10.245.173.254"
-[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.2"
+[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.6"
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/22"
 
 # Accept network type as first parameter, assume gre if unspecified

--- a/profiles/ppc64el
+++ b/profiles/ppc64el
@@ -13,7 +13,7 @@
 [[ -z "$GATEWAY" ]] && export GATEWAY="10.245.168.1"
 [[ -z "$CIDR_EXT" ]] && export CIDR_EXT="10.245.168.0/21"
 [[ -z "$FIP_RANGE" ]] && export FIP_RANGE="10.245.173.0:10.245.173.255"
-[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.2"
+[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.6"
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/22"
 
 # Accept network type as first parameter, assume gre if unspecified

--- a/profiles/ppc64el-v3
+++ b/profiles/ppc64el-v3
@@ -17,7 +17,7 @@ set -ex
 [[ -z "$GATEWAY" ]] && export GATEWAY="10.245.168.1"
 [[ -z "$CIDR_EXT" ]] && export CIDR_EXT="10.245.168.0/21"
 [[ -z "$FIP_RANGE" ]] && export FIP_RANGE="10.245.173.0:10.245.173.255"
-[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.2"
+[[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.168.6"
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/22"
 
 # Accept network type as first parameter, assume gre if unspecified


### PR DESCRIPTION
Some profiles still used lescina as nameserver - instances launched on these servers with ml2 dns enabled were not able to resolve hosts