### PR TITLE
Remove superflous call to juju run in openrc frontend

### DIFF
--- a/rcs/openrc
+++ b/rcs/openrc
@@ -3,7 +3,6 @@ _keystone_unit=$(juju status keystone --format yaml | \
 _keystone_major_version=$(juju status ${_keystone_unit} --format yaml| \
     awk '/^    version:/ {print $2}' | cut -f1 -d\.)
 _keystone_preferred_api_version=$(juju config keystone preferred-api-version)
-_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
 
 if [ $_keystone_major_version -ge 13 -o \
      "$_keystone_preferred_api_version" = '3' ]; then


### PR DESCRIPTION
The frontend script determines which Keystone API version
to use based on Keystone application version and a call to
`juju config`.  Based on this information it sources the
appropriate backend script.

The backend script does the `juju run` call to get unit
private address.

The fact that the frontend script currently also does this
call without a need for the information is a bug.

This commit addresses that.