### PR TITLE
BASH_SOURCE[0] instead of full array

### DIFF
--- a/rcs/openrc
+++ b/rcs/openrc
@@ -7,8 +7,8 @@ _keystone_preferred_api_version=$(juju config keystone preferred-api-version)
 if [ $_keystone_major_version -ge 13 -o \
      "$_keystone_preferred_api_version" = '3' ]; then
     echo Using Keystone v3 API
-    . $(dirname ${BASH_SOURCE[@]})/openrcv3_project
+    . $(dirname ${BASH_SOURCE[0]})/openrcv3_project
 else
     echo Using Keystone v2.0 API
-    . $(dirname ${BASH_SOURCE[@]})/openrcv2
+    . $(dirname ${BASH_SOURCE[0]})/openrcv2
 fi


### PR DESCRIPTION
BASH_SOURCE should use the latest entry in the array (the bash source
calling the rc script) and not the full array, e.g. something that also
called the rc script, giving you multiple results.