### PR TITLE
Add image_ssh_user=cirros to keystone v3 config

### DIFF
--- a/templates/tempest/tempest-v3.conf.template
+++ b/templates/tempest/tempest-v3.conf.template
@@ -47,6 +47,8 @@ lock_path=/tmp
 [scenario]
 img_dir=/home/ubuntu/images
 ssh_user=cirros
+[validation]
+image_ssh_user=cirros
 [service_available]
 ceilometer = true
 cinder = true


### PR DESCRIPTION
Without this change, test_reboot_server_hard and
test_server_basic_ops are failing with errors along the
lines of:

"Please login as \'cirros\' user, not as root\\n\\n"