### PR TITLE
TFix random admin project selection bug

### DIFF
--- a/bin/neutron-ext-net-ksv3
+++ b/bin/neutron-ext-net-ksv3
@@ -72,11 +72,7 @@ if __name__ == '__main__':
     quantum = client.Client(session=sess)
 
     # Resolve tenant id
-    project_id = None
-    for proj in [t._info for t in keystone.projects.list()]:
-        if (proj['name'] == (opts.project or os.environ['OS_PROJECT_NAME'])):
-            project_id = proj['id']
-            break  # Tenant ID found - stop looking
+    project_id = auth.get_project_id(sess)
     if not project_id:
         logging.error("Unable to locate project id for %s.", opts.tenant)
         sys.exit(1)

--- a/bin/neutron-tenant-net-ksv3
+++ b/bin/neutron-tenant-net-ksv3
@@ -72,11 +72,7 @@ if __name__ == '__main__':
     quantum = client.Client(session=sess)
 
     # Resolve tenant id
-    project_id = None
-    for proj in [t._info for t in keystone.projects.list()]:
-        if (proj['name'] == (opts.project or os.environ['OS_PROJECT_NAME'])):
-            project_id = proj['id']
-            break  # Tenant ID found - stop looking
+    project_id = auth.get_project_id(sess)
     if not project_id:
         logging.error("Unable to locate project id for %s.", opts.tenant)
         sys.exit(1)


### PR DESCRIPTION
When the neutron scripts workout the admin project id they iterate
over all the projects with a name that matches, when a match is found
they exit. However, two admin projects are created and which
order the script finds them in is probably down to their randomly
allocated uuid meaning networks may be created in the wrong admin
project.

The keystone session object has already selected the
correct project based on environment variables so extract the project
id from there.