### PR TITLE
Fix ambiguous relations of nova-cloud-controller

### DIFF
--- a/bundles/sparse/default.yaml
+++ b/bundles/sparse/default.yaml
@@ -108,8 +108,8 @@ base-services:
       charm: cs:heat
   relations:
     - [ keystone, mysql ]
-    - [ nova-cloud-controller, mysql ]
-    - [ nova-cloud-controller, rabbitmq-server ]
+    - [ "nova-cloud-controller:shared-db", mysql ]
+    - [ "nova-cloud-controller:amqp", rabbitmq-server ]
     - [ nova-cloud-controller, glance ]
     - [ nova-cloud-controller, keystone ]
     - [ nova-compute, nova-cloud-controller ]


### PR DESCRIPTION
nova-cloud-controller relations to mysql and rabbitmq-server were
ambiguous, which caused errors during deployment, such as:

jujuclient.exc.EnvError: <Env Error - Details:
 {   'error': 'ambiguous relation: "nova-cloud-controller mysql" could refer to '
             '"nova-cloud-controller:shared-db mysql:shared-db"; '
             '"nova-cloud-controller:shared-db-cell mysql:shared-db"',
    'request-id': 5,
    'response': {}}

Updating relations so that they explicitely point to
"nova-cloud-controller:shared-db" and "nova-cloud-controller:amqp" fixes
the deployment.