### PR TITLE
Use juju storage bindings for swift-storage

### DIFF
--- a/bundles/sparse/default.yaml
+++ b/bundles/sparse/default.yaml
@@ -80,25 +80,22 @@ base-services:
       constraints: mem=1G
       options:
         zone: 1
-        block-device: /dev/vdb
-        overwrite: "true"
-        ephemeral-unmount: "/mnt"
+      storage:
+        block-devices: cinder,10G
     swift-storage-z2:
       charm: cs:swift-storage
       constraints: mem=1G
       options:
         zone: 2
-        block-device: /dev/vdb
-        overwrite: "true"
-        ephemeral-unmount: "/mnt"
+      storage:
+        block-devices: cinder,10G
     swift-storage-z3:
       charm: cs:swift-storage
       constraints: mem=1G
       options:
         zone: 3
-        block-device: /dev/vdb
-        overwrite: "true"
-        ephemeral-unmount: "/mnt"
+      storage:
+        block-devices: cinder,10G
     ceilometer:
       charm: cs:ceilometer
       constraints: mem=1G

--- a/bundles/sparse/next.yaml
+++ b/bundles/sparse/next.yaml
@@ -80,25 +80,22 @@ base-services:
       constraints: mem=1G
       options:
         zone: 1
-        block-device: /dev/vdb
-        overwrite: "true"
-        ephemeral-unmount: "/mnt"
+      storage:
+        block-devices: cinder,10G
     swift-storage-z2:
       charm: cs:~openstack-charmers-next/swift-storage
       constraints: mem=1G
       options:
         zone: 2
-        block-device: /dev/vdb
-        overwrite: "true"
-        ephemeral-unmount: "/mnt"
+      storage:
+        block-devices: cinder,10G
     swift-storage-z3:
       charm: cs:~openstack-charmers-next/swift-storage
       constraints: mem=1G
       options:
         zone: 3
-        block-device: /dev/vdb
-        overwrite: "true"
-        ephemeral-unmount: "/mnt"
+      storage:
+        block-devices: cinder,10G
     ceilometer:
       charm: cs:~openstack-charmers-next/ceilometer
       constraints: mem=1G


### PR DESCRIPTION
Use juju storage bindings for swift storage units to avoid
unclean disks and locked devices.