### PR TITLE
Configure highest available volume api for tempest

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -50,6 +50,8 @@ keystone=$(juju-deployer -f keystone)
 dashboard=$(juju-deployer -f openstack-dashboard)
 ncc=$(juju-deployer -f nova-cloud-controller)
 http=${OS_AUTH_PROTOCOL:-http}
+volume_version=$(openstack endpoint list -c 'Service Type' -f value | grep volumev3 ||
+                 openstack endpoint list -c 'Service Type' -f value | grep volumev2)
 
 # Insert vars into tempest conf
 sed -e "s/__IMAGE_ID__/$image_id/g" -e "s/__IMAGE_ALT_ID__/$image_alt_id/g" \
@@ -59,6 +61,7 @@ sed -e "s/__IMAGE_ID__/$image_id/g" -e "s/__IMAGE_ALT_ID__/$image_alt_id/g" \
     -e "s/__NAMESERVER__/$NAMESERVER/g" \
     -e "s/__CIDR_PRIV__/${CIDR_PRIV////\\/}/g" \
     -e "s/__NCC__/$ncc/g" \
+    -e "s/__VOLUME_VERSION__/$volume_version/g" \
     templates/tempest/tempest.conf.template > tempest.conf
 
 # Git tempest, place the rendered tempest template

--- a/templates/tempest/tempest-v3.conf.template
+++ b/templates/tempest/tempest-v3.conf.template
@@ -92,7 +92,3 @@ storage_protocol = ceph
 
 [volume-feature-enabled]
 backup = false
-# NOTE(jamespage): These are release specific
-api_v1 = false
-api_v2 = true
-api_v3 = true

--- a/templates/tempest/tempest.conf.template
+++ b/templates/tempest/tempest.conf.template
@@ -88,10 +88,7 @@ zaqar = false
 [volume]
 backend_names = cinder-ceph
 storage_protocol = ceph
+catalog_type = __VOLUME_VERSION__
 
 [volume-feature-enabled]
 backup = false
-# NOTE(jamespage): These are release specific
-api_v1 = false
-api_v2 = true
-api_v3 = true


### PR DESCRIPTION
Ensure the volumev3 endpoint is used if it is available, and volumev2
is used otherwise.

Tempest will run volume tests against one volume API, either volumev2
or volumev3. As of Pike, volumev3 is enabled by the cinder charm.

The deprecated api_v1, api_v2, and api_v3 options are dropped in favor
of catalog_type, which defaults to volumev3.