### PR TITLE
Stop processing units after first match

### DIFF
--- a/rcs/openrc
+++ b/rcs/openrc
@@ -1,7 +1,7 @@
 _keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
 _keystone_major_version=$(juju status ${_keystone_unit} --format yaml| \
-    awk '/^    version:/ {print $2}' | cut -f1 -d\.)
+    awk '/^    version:/ {print $2; exit}' | cut -f1 -d\.)
 _keystone_preferred_api_version=$(juju config keystone preferred-api-version)
 
 if [ $_keystone_major_version -ge 13 -o \

--- a/rcs/openrcv2
+++ b/rcs/openrcv2
@@ -6,7 +6,7 @@ for param in $_OS_PARAMS; do
 done
 
 _keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
 _keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
 _password=$(juju run --unit ${_keystone_unit} 'leader-get admin_passwd')
 

--- a/rcs/openrcv3_domain
+++ b/rcs/openrcv3_domain
@@ -7,7 +7,7 @@ done
 unset _OS_PARAMS
 
 _keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
 _keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
 _password=$(juju run --unit ${_keystone_unit} 'leader-get admin_passwd')
 

--- a/rcs/openrcv3_project
+++ b/rcs/openrcv3_project
@@ -7,7 +7,7 @@ done
 unset _OS_PARAMS
 
 _keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1}')
+    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
 _keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
 _password=$(juju run --unit ${_keystone_unit} 'leader-get admin_passwd')
 


### PR DESCRIPTION
Starting Juju 2.5 the output of `juju status` with
format modifier contains information about storage
and volumes used in the model when present.

This makes the `openrc` scripts fail due to the awk
program returning multiple matches from its search
for the `keystone` unit.

Applications appear first in the output, so modify
the awk script to stop processing after first match
to amend the situation.

Fixes https://bugs.launchpad.net/openstack-bundles/+bug/1811697