### PR TITLE
fix multiple returns of volume version string

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -50,8 +50,8 @@ keystone=$(juju-deployer -f keystone)
 dashboard=$(juju-deployer -f openstack-dashboard)
 ncc=$(juju-deployer -f nova-cloud-controller)
 http=${OS_AUTH_PROTOCOL:-http}
-volume_version=$(openstack endpoint list -c 'Service Type' -f value | grep volumev3 ||
-                 openstack endpoint list -c 'Service Type' -f value | grep volumev2)
+volume_version=$(openstack endpoint list -c 'Service Type' -f value | grep volumev3 | head -n1 ||
+                 openstack endpoint list -c 'Service Type' -f value | grep volumev2 | head -n1)
 
 # Insert vars into tempest conf
 sed -e "s/__IMAGE_ID__/$image_id/g" -e "s/__IMAGE_ALT_ID__/$image_alt_id/g" \


### PR DESCRIPTION

The sed command was breaking when multiple lines were returned from the openstack endpoint list command. This is a fix for picking only the first one.
