### PR TITLE
Flavors stein

### DIFF
--- a/profiles/common
+++ b/profiles/common
@@ -148,8 +148,8 @@ function create_tempest_users_v3 {
 
 function create_tempest_flavors {
     openstack flavor show m1.cirros || openstack flavor create  --id 6 --ram 64  --disk 1 --vcpus 1 m1.cirros
-    openstack flavor show m1.tempest || openstack flavor create --id 7 --ram 256 --disk 0 --vcpus 1 m1.tempest
-    openstack flavor show m2.tempest || openstack flavor create --id 8 --ram 512 --disk 0 --vcpus 1 m2.tempest
+    openstack flavor show m1.tempest || openstack flavor create --id 7 --ram 256 --disk 1 --vcpus 1 m1.tempest
+    openstack flavor show m2.tempest || openstack flavor create --id 8 --ram 512 --disk 1 --vcpus 1 m2.tempest
 }
 
 function create_default_flavors {

--- a/profiles/keystonev3
+++ b/profiles/keystonev3
@@ -51,7 +51,7 @@ keystone=$(juju-deployer -f keystone)
 dashboard=$(juju-deployer -f openstack-dashboard)
 ncc=$(juju-deployer -f nova-cloud-controller)
 http=${OS_AUTH_PROTOCOL:-http}
-default_domain_id=$(openstack domain list | awk '/default/ {print $2}')
+default_domain_id=$(openstack domain list | awk '/admin_domain/ {print $2}')
 
 # Insert vars into tempest conf
 sed -e "s/__IMAGE_ID__/$image_id/g" -e "s/__IMAGE_ALT_ID__/$image_alt_id/g" \


### PR DESCRIPTION
Set a disk size for tempest testing failures to avoid test failures for stein and later, where only boot from volume with disk size 0 is allowed