### PR TITLE
set cinder volume size to 5G by default

### DIFF
--- a/templates/tempest/tempest-v3.conf.template
+++ b/templates/tempest/tempest-v3.conf.template
@@ -89,6 +89,7 @@ zaqar = false
 [volume]
 backend_names = cinder-ceph
 storage_protocol = ceph
+volume_size = 5
 
 [volume-feature-enabled]
 backup = false

--- a/templates/tempest/tempest.conf.template
+++ b/templates/tempest/tempest.conf.template
@@ -89,6 +89,7 @@ zaqar = false
 backend_names = cinder-ceph
 storage_protocol = ceph
 catalog_type = __VOLUME_VERSION__
+volume_size = 5
 
 [volume-feature-enabled]
 backup = false


### PR DESCRIPTION
default is 1G, which is not large enough for ubuntu images in case
we use those rather than cirros