### PR TITLE
Account for charm config changes in 20.05 release

### DIFF
--- a/bundles/sparse/next.yaml
+++ b/bundles/sparse/next.yaml
@@ -23,7 +23,6 @@ openstack-services:
       constraints: mem=1G
       options:
         admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: cs:~openstack-charmers-next/openstack-dashboard
       constraints: mem=1G
@@ -50,6 +49,8 @@ openstack-services:
       charm: cs:~openstack-charmers-next/neutron-api
       constraints: mem=1G
       options:
+        manage-neutron-plugin-legacy-mode: True
+        neutron-plugin: ovs
         neutron-security-groups: True
         enable-ml2-port-security: True
         enable-qos: True


### PR DESCRIPTION
Update sparse next.yaml to deal with charm config changes in
the upcoming 20.05 release.

manage-neutron-plugin-legacy-mode no longer defaults to True,
and if set to True will require neutron-plugin config to be set.

keystone admin-token config option has been dropped in favor of
keystone-manage bootstrap.