### PR TITLE
Fix tox failure by moving on to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: python
 python:
-    - "2.7"
-    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
 install: pip install tox-travis
 script: tox -e lint

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME TERM
-basepython = python3.6
+basepython = python3
 deps = -r{toxinidir}/requirements.txt
 install_command =
   pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME TERM
-basepython = python2.7
+basepython = python3.6
 deps = -r{toxinidir}/requirements.txt
 install_command =
   pip install {opts} {packages}


### PR DESCRIPTION
With Python 2.7:

```
  File ".../openstack-charm-testing/.tox/openstack-client/lib/python2.7/site-packages/openstack/utils.py", line 13, in <module>
    import queue
ImportError: No module named queue
```