### PR TITLE
Ensure openrc works in LXD containers too

### DIFF
--- a/rcs/openrc
+++ b/rcs/openrc
@@ -15,7 +15,7 @@ if [ -d ~/snap/openstackclients/common/ ]; then
 else
   _root_ca=/tmp/root-ca.crt
 fi
-juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' > $_root_ca 2>/dev/null
+juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' | tee $_root_ca >/dev/null 2>&1
 
 if [ $_keystone_major_version -ge 13 -o \
      "$_keystone_preferred_api_version" = '3' ]; then


### PR DESCRIPTION
With the redirection ">", /tmp/root-ca.crt will be empty always since
the output from Juju CLI snap will be blocked by AppArmor with the
following error as of today.

audit[1238840]: AVC apparmor="DENIED" operation="file_inherit"
namespace="root//lxd-quick-maas_<var-snap-lxd-common-lxd>"
profile="/snap/snapd/10492/usr/lib/snapd/snap-confine"
name="/tmp/root-ca.crt" pid=1238840 comm="snap-confine"
requested_mask="w" denied_mask="w" fsuid=1001000 ouid=1001000

Let's workaround it by using the pipe. More details:
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753