### PR TITLE
Store CA Certificate with model prefix when JUJU_MODEL used

### DIFF
--- a/rcs/openrc
+++ b/rcs/openrc
@@ -11,9 +11,9 @@ openstack --version 2>&1 > /dev/null || true
 if [ -d ~/snap/openstackclients/common/ ]; then
   # When using the openstackclients confined snap the certificate has to be
   # placed in a location reachable by the clients in the snap.
-  _root_ca=~/snap/openstackclients/common/root-ca.crt
+  _root_ca=~/snap/openstackclients/common/${JUJU_MODEL-""}root-ca.crt
 else
-  _root_ca=/tmp/root-ca.crt
+  _root_ca=/tmp/${JUJU_MODEL-""}root-ca.crt
 fi
 juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' > $_root_ca 2>/dev/null
 


### PR DESCRIPTION
To allow for a single juju client environment to be used by
multiple users to manage multiple models simultaneously: Prefix
stored certificate name with model name from JUJU_MODEL
environment variable.